### PR TITLE
[Native][UWP] Fix items list not loading

### DIFF
--- a/MasterDetail-Native/MasterDetail.UWP/App.xaml.cs
+++ b/MasterDetail-Native/MasterDetail.UWP/App.xaml.cs
@@ -59,6 +59,8 @@ namespace MasterDetail.UWP
 
                 rootFrame.NavigationFailed += OnNavigationFailed;
 
+                MasterDetail.App.Initialize();
+
                 if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
                 {
                     //TODO: Load state from previously suspended application

--- a/MasterDetail-Native/MasterDetail.UWP/Views/MainPivot.xaml.cs
+++ b/MasterDetail-Native/MasterDetail.UWP/Views/MainPivot.xaml.cs
@@ -36,17 +36,18 @@ namespace MasterDetail.UWP.Views
         public MainPivot()
         {
             InitializeComponent();
+
+            browseViewModel = (ItemsViewModel)this.DataContext;
+            loadItems = browseViewModel.ExecuteLoadItemsCommand();
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-
-            browseViewModel = (ItemsViewModel)this.DataContext;
-            loadItems = browseViewModel.ExecuteLoadItemsCommand();
-            loadItems.Wait();
             gvItems.ItemsSource = browseViewModel.Items;
             gvItems.ItemClick += GvItems_ItemClick;
-          
+
+            if (browseViewModel.Items.Count == 0)
+                loadItems.Wait();
         }
 
 


### PR DESCRIPTION
The items were not loading because `MasterDetail.App` had not been initialized so the DataStore was not resolving. I put the initialization in `OnLaunched()` as this gets called when the app is opened and before any page gets loaded.

I also moved where we set `browseViewModel` and `loadItems` so it's more inline with Android/iOS. This means doing it in the constructor since this is where UWP loads the view since it lacks an equivalent `OnCreateView()`/`ViewDidLoad()`.